### PR TITLE
Fix README for env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ Dit is een website voor een medische injector. De website is ontworpen om eenvou
 ## Installatie
 
 Kopieer eerst het bestand `.env.example` naar `.env` en vul de juiste waarden in voordat je `pnpm run dev` of `pnpm run build` uitvoert.
+
+Zorg er daarbij voor dat `PUBLIC_BOOKING_LINK` is ingevuld. Als deze variabele ontbreekt krijg je bij het opstarten de foutmelding:
+
+```
+SyntaxError: The requested module '/@id/__x00__virtual:$env/static/public' does not provide an export named 'PUBLIC_BOOKING_LINK'
+```
+
+Door de variabele `PUBLIC_BOOKING_LINK` in `.env` te plaatsen verdwijnt deze fout.


### PR DESCRIPTION
## Summary
- explain missing PUBLIC_BOOKING_LINK error in README

## Testing
- `pnpm run lint` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_684093ff35a48333b007b404204e6cbb